### PR TITLE
One rerun-if-changed per line

### DIFF
--- a/src/generate.rs
+++ b/src/generate.rs
@@ -187,7 +187,7 @@ impl Builder {
 }
 
 fn rerun_if_changed(path: &Path) {
-    print!("cargo:rerun-if-changed={}", path.display());
+    println!("cargo:rerun-if-changed={}", path.display());
 }
 
 struct Binaries {


### PR DESCRIPTION
Per the documentation, there should be 1 `rerun-if-changed` per line:

https://doc.rust-lang.org/cargo/reference/build-scripts.html#cargorerun-if-changedpath
```
To request a re-run on any changes within an entire directory, print a line for the directory and separate lines for everything inside it, recursively.
```
Specifically `separate lines for everything inside it`