### PR TITLE
Fix generated paths on Windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,4 @@ ignore = "0.4"
 syn = { version = "1.0", features = ["full", "visit"] }
 proc-macro2 = "1.0"
 pathdiff = "0.2"
+path-slash = "0.1"

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -1,5 +1,5 @@
-use std::path::{Path, PathBuf};
 use path_slash::PathExt;
+use std::path::{Path, PathBuf};
 
 /// Build mode of the crate
 #[derive(Copy, Clone, Debug)]
@@ -185,7 +185,7 @@ impl Builder {
         }
 
         let rel_gdnlib_path = pathdiff::diff_paths(&gdnlib_path, &godot_project_dir)
-        .expect("Unable to create relative path between Godot project and library output");
+            .expect("Unable to create relative path between Godot project and library output");
 
         let prefix;
         let output_path;


### PR DESCRIPTION
Fixed generated paths on Windows. Have tested relative paths and seams to work okay unsure about absolute paths.
New to Rust lang so the code is probably hacky, just how I solved it.