### PR TITLE
Fixes windows path name generation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ syn = { version = "1.0", features = ["full", "visit"] }
 proc-macro2 = "1.0"
 pathdiff = "0.2"
 path-slash = "0.1"
+dunce = "1.0.1"
 
 [dev-dependencies]
 tempfile = "3.1.0"

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -108,25 +108,25 @@ impl Builder {
             .expect("Package name not given and unable to find");
         let godot_project_dir = self
             .godot_project_dir
-            .and_then(|path| path.canonicalize().ok())
+            .and_then(|path| dunce::canonicalize(path).ok())
             .expect("Godot project dir not given");
         let godot_resource_output_dir = self
             .godot_resource_output_dir
-            .and_then(|path| path.canonicalize().ok())
+            .and_then(|path| dunce::canonicalize(path).ok())
             .unwrap_or_else(|| godot_project_dir.join("native"));
         let target_dir = self
             .target_dir
-            .and_then(|path| path.canonicalize().ok())
+            .and_then(|path| dunce::canonicalize(path).ok())
             .or_else(|| {
                 let dir = std::env::var("CARGO_TARGET_DIR").ok()?;
-                PathBuf::from(dir).canonicalize().ok()
+                dunce::canonicalize(PathBuf::from(dir)).ok()
             })
             .or_else(|| {
                 let dir = std::env::var("OUT_DIR").ok()?;
                 let out_path = PathBuf::from(&dir);
 
                 // target/{debug/release}/build/{crate}/out
-                out_path.join("../../../../").canonicalize().ok()
+                dunce::canonicalize(out_path.join("../../../../")).ok()
             })
             .expect("Target dir not given and unable to find");
         let build_mode = self

--- a/tests/resource.rs
+++ b/tests/resource.rs
@@ -34,6 +34,8 @@ fn gdnlib_target_in_project() {
 
 #[test]
 fn gdnlib_target_outside_of_project() {
+    use path_slash::PathExt;
+
     let godot_proj_dir = tempfile::tempdir().unwrap();
     let target_dir = tempfile::tempdir().unwrap();
     let asset_dir = godot_proj_dir.path().join("native");
@@ -55,23 +57,24 @@ fn gdnlib_target_outside_of_project() {
 
     let content = std::fs::read_to_string(&gdnlib_path).unwrap();
 
+    // Use the same canocialize function as the generator for target path comparison
+    let target_dir = dunce::canonicalize(target_dir.path())
+        .unwrap()
+        .to_slash()
+        .unwrap();
+
     // make sure it doesn't use `res://`
 
     // check linux
-    assert!(content.contains(&format!(
-        "=\"{}/debug/libgenerator_test.so\"",
-        target_dir.path().display()
-    )));
+    assert!(content.contains(&format!("=\"{}/debug/libgenerator_test.so\"", target_dir)));
+
     // check android aarch64
     assert!(content.contains(&format!(
         "=\"{}/aarch64-linux-android/debug/libgenerator_test.so\"",
-        target_dir.path().display()
+        target_dir
     )));
     // check windows, the path should still be with forward slashes
-    assert!(content.contains(&format!(
-        "=\"{}/debug/generator_test.dll\"",
-        target_dir.path().display()
-    )));
+    assert!(content.contains(&format!("=\"{}/debug/generator_test.dll\"", target_dir)));
 }
 
 #[test]


### PR DESCRIPTION
Replace fs::canonicalize with dunce::canonicalize
This is to help with projects that may not work well with UNC paths.

Update tests to also use same canonicalize func.
Also use same path direction so on windows its always same with to_slash

Related to https://github.com/godot-rust/project-utils/issues/11