### PR TITLE
Create custom godot_resource_output_dir if it doesn't exist

### DIFF
--- a/src/generate.rs
+++ b/src/generate.rs
@@ -131,8 +131,10 @@ impl Builder {
             .expect("Godot project dir not given");
         let godot_resource_output_dir = self
             .godot_resource_output_dir
+            .or_else(|| Some(godot_project_dir.join("native")))
+            .and_then(|path| std::fs::create_dir_all(&path).ok().map(|_| path))
             .and_then(|path| dunce::canonicalize(path).ok())
-            .unwrap_or_else(|| godot_project_dir.join("native"));
+            .expect("Unable to create godot_resource_output_dir");
         let target_dir = self
             .target_dir
             .and_then(|path| dunce::canonicalize(path).ok())
@@ -159,8 +161,6 @@ impl Builder {
                 }
             })
             .expect("Build mode not given and unable to find");
-
-        std::fs::create_dir_all(&godot_resource_output_dir)?;
 
         let lib_ext = match self.lib_format {
             Some(LibFormat::Gdnlib) | None => "gdnlib",


### PR DESCRIPTION
If a custom `godot_resource_output_dir` is set and does not yet exist, canonicalization will fail and the generator will currently silently fall back to `native`. With this PR, it will instead fall back to `native` only if a custom directory is not given, and then panic if it is unable to either create or canonicalize the resulting path.